### PR TITLE
Don't iterate windows, when already at correct window

### DIFF
--- a/src/WebdriverClassicDriver.php
+++ b/src/WebdriverClassicDriver.php
@@ -1013,6 +1013,12 @@ class WebdriverClassicDriver extends CoreDriver
      */
     private function withWindow(?string $name, callable $callback): void
     {
+        if ($name === null) {
+            $callback();
+
+            return;
+        }
+
         $origName = $this->getWindowName();
 
         try {


### PR DESCRIPTION
I've noticed, that when trying to resize/maximize the current window several calls are made to the Selenium server to verify if we're at the right window. IMO they're unnecessary because we're surely at the correct window already.

P.S.
There is no test to verify, that resizing/maximizing non-current window works.

