### PR TITLE
Wrap WebDriver exception about failed to load page into DriverException

### DIFF
--- a/src/WebdriverClassicDriver.php
+++ b/src/WebdriverClassicDriver.php
@@ -14,6 +14,8 @@ use Behat\Mink\Driver\CoreDriver;
 use Behat\Mink\Exception\DriverException;
 use Facebook\WebDriver\Exception\NoSuchCookieException;
 use Facebook\WebDriver\Exception\NoSuchElementException;
+use Facebook\WebDriver\Exception\ScriptTimeoutException;
+use Facebook\WebDriver\Exception\TimeoutException;
 use Facebook\WebDriver\Exception\UnsupportedOperationException;
 use Facebook\WebDriver\Exception\WebDriverException;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
@@ -155,7 +157,11 @@ class WebdriverClassicDriver extends CoreDriver
 
     public function visit(string $url): void
     {
-        $this->getWebDriver()->navigate()->to($url);
+        try {
+            $this->getWebDriver()->navigate()->to($url);
+        } catch (TimeoutException|ScriptTimeoutException $e) {
+            throw new DriverException('Page failed to load: ' . $e->getMessage(), 0, $e);
+        }
     }
 
     public function getCurrentUrl(): string

--- a/tests/Custom/TimeoutTest.php
+++ b/tests/Custom/TimeoutTest.php
@@ -35,6 +35,7 @@ class TimeoutTest extends TestCase
         assert($driver instanceof WebdriverClassicDriver);
 
         $this->expectException(DriverException::class);
+        $this->expectExceptionMessage('Invalid timeout type: invalid');
 
         $driver->setTimeouts(['invalid' => 0]);
     }
@@ -63,5 +64,18 @@ class TimeoutTest extends TestCase
         $element = $this->getSession()->getPage()->find('css', '#waitable > div');
 
         $this->assertNotNull($element);
+    }
+
+    public function testShortPageLoadTimeoutThrowsException(): void
+    {
+        $session = $this->getSession();
+        $driver = $session->getDriver();
+        \assert($driver instanceof WebdriverClassicDriver);
+
+        $driver->setTimeouts(['page' => 500]);
+
+        $this->expectException(DriverException::class);
+        $this->expectExceptionMessage('Page failed to load: ');
+        $session->visit($this->pathTo('/page_load.php?sleep=2'));
     }
 }


### PR DESCRIPTION
Wrap WebDriver's `TimeoutException` and `ScriptTimeoutException` exceptions into `DriverException`, when the page wasn't opened due to `page` timeout being met.

P.S.
Based on https://github.com/minkphp/MinkSelenium2Driver/pull/400 .