### PR TITLE
Simplify custom tests

### DIFF
--- a/src/WebdriverClassicDriver.php
+++ b/src/WebdriverClassicDriver.php
@@ -956,12 +956,15 @@ class WebdriverClassicDriver extends CoreDriver
                     case 'script':
                         $timeouts->setScriptTimeout($param / 1000);
                         break;
+
                     case 'implicit':
                         $timeouts->implicitlyWait($param / 1000);
                         break;
+
                     case 'page':
                         $timeouts->pageLoadTimeout($param / 1000);
                         break;
+
                     default:
                         throw new DriverException("Invalid timeout type: $type");
                 }

--- a/tests/Custom/SessionTest.php
+++ b/tests/Custom/SessionTest.php
@@ -2,34 +2,20 @@
 
 namespace Mink\WebdriverClassicDriver\Tests\Custom;
 
-use Behat\Mink\Exception\DriverException;
-use Behat\Mink\Tests\Driver\TestCase;
-use Mink\WebdriverClassicDriver\Tests\WebdriverClassicConfig;
-use Mink\WebdriverClassicDriver\WebdriverClassicDriver;
-
 class SessionTest extends TestCase
 {
-    protected function setUp(): void
+    public function testNewDriverShouldNotHaveSessionId(): void
     {
-        parent::setUp();
+        $driver = $this->driver;
 
-        $this->getSession()->start();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->getSession()->stop();
-
-        parent::tearDown();
-    }
-
-    public function testGetWebDriverSessionId(): void
-    {
-        $driver = $this->getSession()->getDriver();
-        assert($driver instanceof WebdriverClassicDriver);
-        $this->assertNotEmpty($driver->getWebDriverSessionId(), 'Started session should have an ID');
-
-        $driver = new WebdriverClassicDriver();
         $this->assertNull($driver->getWebDriverSessionId(), 'Non-started session should not have an ID');
+    }
+
+    public function testStartedDriverShouldHaveSessionId(): void
+    {
+        $driver = $this->driver;
+        $driver->start();
+
+        $this->assertNotEmpty($driver->getWebDriverSessionId(), 'Started session should have an ID');
     }
 }

--- a/tests/Custom/TestCase.php
+++ b/tests/Custom/TestCase.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Mink\WebdriverClassicDriver\Tests\Custom;
+
+use Mink\WebdriverClassicDriver\Tests\WebdriverClassicConfig;
+use Mink\WebdriverClassicDriver\WebdriverClassicDriver;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+
+class TestCase extends \PHPUnit\Framework\TestCase
+{
+    protected WebdriverClassicDriver $driver;
+
+    use ExpectDeprecationTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->driver = $this->getConfig()->createDriver();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        if ($this->driver->isStarted()) {
+            $this->driver->stop();
+        }
+    }
+
+    protected function pathTo(string $path): string
+    {
+        return rtrim($this->getConfig()->getWebFixturesUrl(), '/') . '/' . ltrim($path, '/');
+    }
+
+    protected function getConfig(): WebdriverClassicConfig
+    {
+        return WebdriverClassicConfig::getInstance();
+    }
+}

--- a/tests/Custom/WebDriverTest.php
+++ b/tests/Custom/WebDriverTest.php
@@ -3,30 +3,10 @@
 namespace Mink\WebdriverClassicDriver\Tests\Custom;
 
 use Behat\Mink\Exception\DriverException;
-use Mink\WebdriverClassicDriver\Tests\WebdriverClassicConfig;
 use Mink\WebdriverClassicDriver\WebdriverClassicDriver;
-use PHPUnit\Framework\TestCase;
 
 class WebDriverTest extends TestCase
 {
-    private WebdriverClassicDriver $driver;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->driver = WebdriverClassicConfig::getInstance()->createDriver();
-    }
-
-    protected function tearDown(): void
-    {
-        if ($this->driver->isStarted()) {
-            $this->driver->stop();
-        }
-
-        parent::tearDown();
-    }
-
     public function testDriverMustBeStartedBeforeUse(): void
     {
         $this->expectException(DriverException::class);
@@ -88,7 +68,7 @@ class WebDriverTest extends TestCase
     public function testClassicDriverCanProvideBrowserName(): void
     {
         $this->assertSame(
-            WebdriverClassicConfig::getInstance()->getBrowserName(),
+            $this->getConfig()->getBrowserName(),
             $this->driver->getBrowserName()
         );
     }


### PR DESCRIPTION
The base TestCase from driver-testsuite has some disadvantages:
- it tends to require some additional boilerplate for most driver-specific tests
- it's a bit unclear/convoluted for simple test scenarios
- in principle, tests requiring mink/getSession() are probably misplaced and should exist in the driver testsuite when you think about it

With that in mind, I came up with a simple base TestCase class that copies some of the functionality of the original one.
In my opinion, we should make helper traits out of the original one, which driver authors could use - but that's a bit off topic.