### PR TITLE
Added default browser name for tests to the test suite config

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,6 +24,8 @@
         <!-- MacOS -->
         <!--<server name="WEB_FIXTURES_HOST" value="http://docker.for.mac.localhost:8002"/>-->
 
+        <server name="WEB_FIXTURES_BROWSER" value="chrome" />
+
         <!-- where driver will connect to -->
         <server name="DRIVER_URL" value="http://localhost:4444/wd/hub"/>
 


### PR DESCRIPTION
This doesn't work, because `WEB_FIXTURES_BROWSER` in test suite is read using `getenv`, while other settings are read using `$_SERVER`.

It is likely related to #44.