### PR TITLE
Fix and streamline capability handling

### DIFF
--- a/src/WebdriverClassicDriver.php
+++ b/src/WebdriverClassicDriver.php
@@ -789,29 +789,22 @@ class WebdriverClassicDriver extends CoreDriver
      */
     private function initCapabilities(array $desiredCapabilities): DesiredCapabilities
     {
-        // Build base capabilities
-        $caps = $this->getBrowserSpecificCapabilities() ?? new DesiredCapabilities();
+        $capabilities = $this->createBrowserSpecificCapabilities();
 
-        // Set defaults
-        $defaults = array_merge(
-            self::DEFAULT_CAPABILITIES['default'],
-            self::DEFAULT_CAPABILITIES[$this->getNormalisedBrowserName()] ?? []
-        );
-        foreach ($defaults as $key => $value) {
-            if ($caps->getCapability($key) === null) {
-                $caps->setCapability($key, $value);
-            }
+        foreach (
+            array_merge(
+                self::DEFAULT_CAPABILITIES['default'],
+                self::DEFAULT_CAPABILITIES[$this->getNormalisedBrowserName()] ?? [],
+                $desiredCapabilities,
+            ) as $capabilityKey => $capabilityValue
+        ) {
+            $capabilities->setCapability($capabilityKey, $capabilityValue);
         }
 
-        // Merge in other requested types
-        foreach ($desiredCapabilities as $key => $value) {
-            $caps->setCapability($key, $value);
-        }
-
-        return $caps;
+        return $capabilities;
     }
 
-    private function getBrowserSpecificCapabilities(): ?DesiredCapabilities
+    private function createBrowserSpecificCapabilities(): DesiredCapabilities
     {
         switch ($this->getNormalisedBrowserName()) {
             case WebDriverBrowserType::FIREFOX:
@@ -855,7 +848,7 @@ class WebdriverClassicDriver extends CoreDriver
             case WebDriverBrowserType::MOCK:
             case WebDriverBrowserType::IE_HTA:
             default:
-                return null;
+                return new DesiredCapabilities();
         }
     }
 

--- a/src/WebdriverClassicDriver.php
+++ b/src/WebdriverClassicDriver.php
@@ -762,7 +762,7 @@ class WebdriverClassicDriver extends CoreDriver
             throw new DriverException('Base driver has already been created');
         }
 
-        $this->webDriver = RemoteWebDriver::create($this->webDriverHost, $this->desiredCapabilities);
+        $this->webDriver = RemoteWebDriver::create($this->webDriverHost, $this->getDesiredCapabilities());
     }
 
     /**
@@ -775,6 +775,11 @@ class WebdriverClassicDriver extends CoreDriver
         }
 
         throw new DriverException('Base driver has not been created');
+    }
+
+    protected function getDesiredCapabilities(): array
+    {
+        return $this->desiredCapabilities->toArray();
     }
 
     private function getNormalisedBrowserName(): string

--- a/tests/Custom/CapabilityTest.php
+++ b/tests/Custom/CapabilityTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Mink\WebdriverClassicDriver\Tests\Custom;
+
+use Mink\WebdriverClassicDriver\WebdriverClassicDriver;
+
+class CapabilityTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @param array<string, mixed> $desiredCapabilities
+     * @param array<string, mixed> $expectedCapabilities
+     *
+     * @dataProvider capabilitiesDataProvider
+     */
+    public function testThatCapabilitiesAreAsExpected(string $browserName, array $desiredCapabilities, array $expectedCapabilities): void
+    {
+        $driver = $this->createDriverExposingCapabilities($browserName, $desiredCapabilities);
+
+        $this->assertSame($expectedCapabilities, $driver->capabilities);
+    }
+
+    public static function capabilitiesDataProvider(): iterable
+    {
+        yield 'unknown browser starts with default driver capabilities' => [
+            'browserName' => 'fake browser',
+            'desiredCapabilities' => [],
+            'expectedCapabilities' => [
+                'platform' => 'ANY',
+                'name' => 'Behat Test',
+                'deviceOrientation' => 'landscape',
+                'deviceType' => 'desktop',
+            ],
+        ];
+
+        yield 'default capabilities can be customised' => [
+            'browserName' => 'fake browser',
+            'desiredCapabilities' => [
+                'something' => 'custom',
+                'name' => 'Custom Test',
+            ],
+            'expectedCapabilities' => [
+                'platform' => 'ANY',
+                'name' => 'Custom Test',
+                'deviceOrientation' => 'landscape',
+                'deviceType' => 'desktop',
+                'something' => 'custom',
+            ],
+        ];
+
+        yield 'browser-specific default capabilities are added' => [
+            'browserName' => 'chrome',
+            'desiredCapabilities' => [],
+            'expectedCapabilities' => [
+                'browserName' => 'chrome',
+                'platform' => 'ANY',
+                'name' => 'Behat Test',
+                'deviceOrientation' => 'landscape',
+                'deviceType' => 'desktop',
+                'goog:chromeOptions' => [
+                    'excludeSwitches' => ['enable-automation'],
+                ],
+            ],
+        ];
+
+        yield 'browser-specific default capabilities can be customised' => [
+            'browserName' => 'chrome',
+            'desiredCapabilities' => [
+                'name' => 'Custom Test',
+                'goog:chromeOptions' => ['args' => ['a', 'b', 'c']],
+            ],
+            'expectedCapabilities' => [
+                'browserName' => 'chrome',
+                'platform' => 'ANY',
+                'name' => 'Custom Test',
+                'deviceOrientation' => 'landscape',
+                'deviceType' => 'desktop',
+                'goog:chromeOptions' => ['args' => ['a', 'b', 'c']],
+            ],
+        ];
+    }
+
+    /**
+     * @param string $browserName
+     * @param array<string, mixed> $desiredCapabilities
+     * @return WebdriverClassicDriver&object{capabilities: array<string, mixed>}
+     */
+    private function createDriverExposingCapabilities(string $browserName, array $desiredCapabilities = []): WebdriverClassicDriver
+    {
+        return new class($browserName, $desiredCapabilities) extends WebdriverClassicDriver {
+            public ?array $capabilities = null;
+
+            public function __construct(string $browserName, array $desiredCapabilities)
+            {
+                parent::__construct($browserName, $desiredCapabilities);
+
+                $this->capabilities = $this->getDesiredCapabilities();
+            }
+        };
+    }
+}

--- a/tests/Custom/CapabilityTest.php
+++ b/tests/Custom/CapabilityTest.php
@@ -87,6 +87,9 @@ class CapabilityTest extends \PHPUnit\Framework\TestCase
     private function createDriverExposingCapabilities(string $browserName, array $desiredCapabilities = []): WebdriverClassicDriver
     {
         return new class($browserName, $desiredCapabilities) extends WebdriverClassicDriver {
+            /**
+             * @var null|array<string, mixed>
+             */
             public ?array $capabilities = null;
 
             public function __construct(string $browserName, array $desiredCapabilities)

--- a/tests/Custom/CapabilityTest.php
+++ b/tests/Custom/CapabilityTest.php
@@ -82,15 +82,15 @@ class CapabilityTest extends \PHPUnit\Framework\TestCase
     /**
      * @param string $browserName
      * @param array<string, mixed> $desiredCapabilities
-     * @return WebdriverClassicDriver&object{capabilities: null|array<string, mixed>}
+     * @return WebdriverClassicDriver&object{capabilities: array<string, mixed>}
      */
     private function createDriverExposingCapabilities(string $browserName, array $desiredCapabilities = []): WebdriverClassicDriver
     {
         return new class($browserName, $desiredCapabilities) extends WebdriverClassicDriver {
             /**
-             * @var null|array<string, mixed>
+             * @var array<string, mixed>
              */
-            public ?array $capabilities = null;
+            public array $capabilities;
 
             public function __construct(string $browserName, array $desiredCapabilities)
             {

--- a/tests/Custom/CapabilityTest.php
+++ b/tests/Custom/CapabilityTest.php
@@ -82,7 +82,7 @@ class CapabilityTest extends \PHPUnit\Framework\TestCase
     /**
      * @param string $browserName
      * @param array<string, mixed> $desiredCapabilities
-     * @return WebdriverClassicDriver&object{capabilities: array<string, mixed>}
+     * @return WebdriverClassicDriver&object{capabilities: null|array<string, mixed>}
      */
     private function createDriverExposingCapabilities(string $browserName, array $desiredCapabilities = []): WebdriverClassicDriver
     {


### PR DESCRIPTION
Fixes #46.

## What Changed

1. Fixes code preventing us from overwriting capbalities when they're already set by php-webdriver.
2. Streamlines the flow so that it is clearer how it behaves:
    1. start with the browser-specific capabilities provided by php-webdriver
    2. add mink default capabilities
    3. add mink browser-specific default capabilities
    4. add capabilities defined by the end user
3. 'add', in this case, always overwrites existing capabilities

## Remaining Questions

- How do we test this? (should we even test it?) In principle this is private behaviour and not something accessible from the outside.
- Should we be worried that this is a BC break? Existing users that have broken config would break their system, when in the past that config was unintentionally ignored.