### PR TITLE
Disable Chrome code signing, when used on Mac

### DIFF
--- a/src/WebdriverClassicDriver.php
+++ b/src/WebdriverClassicDriver.php
@@ -47,6 +47,10 @@ class WebdriverClassicDriver extends CoreDriver
             'goog:chromeOptions' => [
                 // disable "Chrome is being controlled.." notification bar
                 'excludeSwitches' => ['enable-automation'],
+                'args' => array(
+                    // disable browser folder cloning on Mac, when tests are executed
+                    'disable-features=MacAppCodeSignClone',
+                ),
             ],
         ],
 


### PR DESCRIPTION
When executing tests in the Google Chrome (or any Chromium-based Web Browser) on Mac you'll notice you're temp folder starts to grow faster than a lightning strikes.

This happens, because upon launching a Web Browser copies itself (whole 300MB folder) into a temp folder. When the Web Browser exists that temp folder isn't deleted.

Since numerous Selenium Server sessions are started/stopped during test suite run you'll get numerous of ~300MB folders residing under a temp folder.

Solution:

* either use ChromeDriver 131.0.6778.70+ (the issue is fixed in https://issues.chromium.org/issues/379125944);
* or specify `--disable-features=MacAppCodeSignClone` as Chrome arguments in WebDriver configuration.

This PR does the later.

P.S.
@uuf6429, I can't seem to get it working. Maybe related to the bug solved in the https://github.com/minkphp/webdriver-classic-driver/pull/51 .