### PR TITLE
Fix various phpstan warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,6 @@ indent_size = 2
 
 [*.php]
 ij_php_align_multiline_parameters = false
+
+[*.neon]
+indent_style = tab

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,11 +1,28 @@
-parameters:
-    level: 8
-    paths:
-        - src
-        - tests
-    checkMissingIterableValueType: false
-    treatPhpDocTypesAsCertain: false
-
 includes:
-    - vendor/phpstan/phpstan-phpunit/extension.neon
-    - vendor/phpstan/phpstan-phpunit/rules.neon
+	- vendor/phpstan/phpstan-phpunit/extension.neon
+	- vendor/phpstan/phpstan-phpunit/rules.neon
+
+parameters:
+	level: 8
+	paths:
+		- src
+		- tests
+	ignoreErrors:
+		-
+			# See: https://github.com/php-webdriver/php-webdriver/pull/1120
+			message: '#^Parameter \#1 \$seconds of method Facebook\\WebDriver\\WebDriverTimeouts\:\:implicitlyWait\(\) expects int, float\|int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/WebdriverClassicDriver.php
+		-
+			# See: https://github.com/php-webdriver/php-webdriver/pull/1120
+			message: '#^Parameter \#1 \$seconds of method Facebook\\WebDriver\\WebDriverTimeouts\:\:pageLoadTimeout\(\) expects int, float\|int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/WebdriverClassicDriver.php
+		-
+			# See: https://github.com/php-webdriver/php-webdriver/pull/1120
+			message: '#^Parameter \#1 \$seconds of method Facebook\\WebDriver\\WebDriverTimeouts\:\:setScriptTimeout\(\) expects int, float\|int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/WebdriverClassicDriver.php

--- a/src/WebdriverClassicDriver.php
+++ b/src/WebdriverClassicDriver.php
@@ -788,11 +788,6 @@ class WebdriverClassicDriver extends CoreDriver
         throw new DriverException('Base driver has not been created');
     }
 
-    protected function getDesiredCapabilities(): array
-    {
-        return $this->desiredCapabilities->toArray();
-    }
-
     // </editor-fold>
 
     // <editor-fold desc="Private Utilities">

--- a/src/WebdriverClassicDriver.php
+++ b/src/WebdriverClassicDriver.php
@@ -32,6 +32,9 @@ use Facebook\WebDriver\WebDriverSelect;
 use JetBrains\PhpStorm\Language;
 
 /**
+ * @phpstan-type TTimeouts array{script?: null|numeric, implicit?: null|numeric, page?: null|numeric, "page load"?: null|numeric, pageLoad?: null|numeric}
+ * @phpstan-type TCapabilities array<string, mixed>
+ * @phpstan-type TElementValue array<array-key, mixed>|bool|mixed|string|null
  * @phpstan-type TWebDriverInstantiator callable(string $driverHost, DesiredCapabilities $capabilities): RemoteWebDriver
  */
 class WebdriverClassicDriver extends CoreDriver
@@ -80,6 +83,9 @@ class WebdriverClassicDriver extends CoreDriver
 
     private DesiredCapabilities $desiredCapabilities;
 
+    /**
+     * @var TTimeouts
+     */
     private array $timeouts = [];
 
     private string $webDriverHost;
@@ -93,6 +99,7 @@ class WebdriverClassicDriver extends CoreDriver
 
     /**
      * @param string $browserName One of 'edge', 'firefox', 'chrome' or any one of {@see WebDriverBrowserType} constants.
+     * @param TCapabilities $desiredCapabilities
      * @param TWebDriverInstantiator|null $webDriverInstantiator
      */
     public function __construct(
@@ -340,12 +347,16 @@ class WebdriverClassicDriver extends CoreDriver
         return $this->executeJsOnXpath($xpath, $script);
     }
 
+    /**
+     * {@inheritdoc}
+     * @return TElementValue
+     */
     public function getValue(
         #[Language('XPath')]
         string $xpath
     ) {
         $element = $this->findElement($xpath);
-        $widgetType = strtolower($element->getTagName() ?? '');
+        $widgetType = $element->getTagName();
         if ($widgetType === 'input') {
             $widgetType = strtolower((string)$element->getAttribute('type'));
         }
@@ -380,13 +391,17 @@ class WebdriverClassicDriver extends CoreDriver
         }
     }
 
+    /**
+     * {@inheritdoc}
+     * @param TElementValue $value
+     */
     public function setValue(
         #[Language('XPath')]
         string $xpath,
         $value
     ): void {
         $element = $this->findElement($xpath);
-        $widgetType = strtolower($element->getTagName() ?? '');
+        $widgetType = $element->getTagName();
         if ($widgetType === 'input') {
             $widgetType = strtolower((string)$element->getAttribute('type'));
         }
@@ -519,7 +534,7 @@ class WebdriverClassicDriver extends CoreDriver
         bool $multiple = false
     ): void {
         $element = $this->findElement($xpath);
-        $tagName = strtolower($element->getTagName() ?? '');
+        $tagName = $element->getTagName();
 
         if ($tagName === 'input' && strtolower((string)$element->getAttribute('type')) === 'radio') {
             $this->selectRadioValue($element, $value);
@@ -747,7 +762,7 @@ class WebdriverClassicDriver extends CoreDriver
     /**
      * Sets the timeouts to apply to the webdriver session
      *
-     * @param array $timeouts The session timeout settings: Array of {script, implicit, page} => time in milliseconds
+     * @param TTimeouts $timeouts The session timeout settings: Array of {script, implicit, page} => time in milliseconds
      * @throws DriverException
      * @api
      */
@@ -804,6 +819,8 @@ class WebdriverClassicDriver extends CoreDriver
 
     /**
      * Detect and assign appropriate browser capabilities
+     *
+     * @param TCapabilities $desiredCapabilities
      *
      * @see https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities
      */

--- a/src/WebdriverClassicDriver.php
+++ b/src/WebdriverClassicDriver.php
@@ -762,7 +762,7 @@ class WebdriverClassicDriver extends CoreDriver
 
     // </editor-fold>
 
-    // <editor-fold desc="Private Utilities">
+    // <editor-fold desc="Extension Points">
 
     /**
      * @throws DriverException

--- a/tests/Custom/CapabilityTest.php
+++ b/tests/Custom/CapabilityTest.php
@@ -7,11 +7,14 @@ use Facebook\WebDriver\WebDriverOptions;
 use Facebook\WebDriver\WebDriverTimeouts;
 use Mink\WebdriverClassicDriver\WebdriverClassicDriver;
 
+/**
+ * @phpstan-import-type TCapabilities from WebdriverClassicDriver
+ */
 class CapabilityTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @param array<string, mixed> $desiredCapabilities
-     * @param array<string, mixed> $expectedCapabilities
+     * @param TCapabilities $desiredCapabilities
+     * @param TCapabilities $expectedCapabilities
      *
      * @dataProvider capabilitiesDataProvider
      */
@@ -39,6 +42,9 @@ class CapabilityTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($expectedCapabilities, $actualCapabilities);
     }
 
+    /**
+     * @return iterable<string, array{browserName: string, desiredCapabilities: TCapabilities, expectedCapabilities: TCapabilities}>
+     */
     public static function capabilitiesDataProvider(): iterable
     {
         yield 'unknown browser starts with default driver capabilities' => [

--- a/tests/Custom/TimeoutTest.php
+++ b/tests/Custom/TimeoutTest.php
@@ -65,6 +65,9 @@ class TimeoutTest extends TestCase
         $this->driver->visit($this->pathTo('/page_load.php?sleep=2'));
     }
 
+    /**
+     * @return iterable<string, array{type: string}>
+     */
     public static function deprecatedPageLoadDataProvider(): iterable
     {
         yield 'selenium 3 style' => ['type' => 'pageLoad'];


### PR DESCRIPTION
Some warnings will show up if we remove `checkMissingIterableValueType` and `treatPhpDocTypesAsCertain` settings (which makes PHPStan somewhat stricter). 

- [x] ⚠️ Must be rebased on main after #56 is merged.